### PR TITLE
Repository Editor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1867,6 +1867,7 @@ dependencies = [
  "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-literal 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "mockito 0.25.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "olpc-cjson 0.1.0",
  "pem 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/tough/Cargo.toml
+++ b/tough/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 [dependencies]
 chrono = { version = "0.4.11", features = ["serde"] }
 hex = "0.4.2"
+maplit = "1.0.1"
 olpc-cjson = { version = "0.1.0", path = "../olpc-cjson" }
 pem = "0.7.0"
 reqwest = { version = "0.10.4", optional = true, default-features = false, features = ["blocking"] }

--- a/tough/src/editor.rs
+++ b/tough/src/editor.rs
@@ -1,0 +1,269 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use crate::datastore::Datastore;
+use crate::error::{self, Result};
+use crate::key_source::KeySource;
+use crate::root_digest::{RootDigest, RootKeys};
+use crate::schema::{
+    Hashes, Role, RoleType, Root, Signature, Signed, Snapshot, SnapshotMeta, Target, Targets,
+    Timestamp, TimestampMeta,
+};
+use crate::transport::{TargetMapTransport, Transport};
+use crate::{Repository, Settings};
+use maplit::hashmap;
+use olpc_cjson::CanonicalFormatter;
+use ring::digest::{digest, SHA256, SHA256_OUTPUT_LEN};
+use ring::rand::{SecureRandom, SystemRandom};
+use serde::Serialize;
+use snafu::ResultExt;
+use std::collections::HashMap;
+use std::num::NonZeroU64;
+use std::path::{Path, PathBuf};
+use url::Url;
+
+/// An in-memory, unsigned TUF repository
+///
+/// This is provided as means to create and update a repository, which can then be signed.
+#[derive(Debug)]
+pub struct RepositoryEditor {
+    pub snapshot: Snapshot,
+    pub timestamp: Timestamp,
+    pub targets: Targets,
+    targets_meta: TargetMapTransport,
+}
+
+impl RepositoryEditor {
+    pub fn new(snapshot: Snapshot, timestamp: Timestamp, targets: Targets) -> RepositoryEditor {
+        RepositoryEditor {
+            snapshot,
+            timestamp,
+            targets,
+            targets_meta: TargetMapTransport {
+                targets: HashMap::new(),
+            },
+        }
+    }
+
+    //pub fn from_path<P>(path: P)
+    //where
+    //    P: AsRef<Path>,
+    //{
+    //}
+
+    pub fn add_target<P>(&mut self, path: P) -> Result<()>
+    where
+        P: AsRef<Path>,
+    {
+        // Get the absolute path to the given target
+        let path = std::fs::canonicalize(path.as_ref()).context(error::AbsolutePath {
+            path: path.as_ref().to_owned(),
+        })?;
+
+        // Build a Target and add it to the Targets struct
+        let (target_name, target) =
+            Target::from_path(&path).context(error::TargetFromPath { path: &path })?;
+        self.targets
+            .targets
+            .insert(target_name.clone(), target.clone());
+
+        // Add the target metadata to the TargetMapTransport
+        // TODO: NOTE HERE ABOUT BOTH FORMS
+        let target_sha256 = &target.hashes.sha256.clone().into_vec();
+        self.targets_meta.targets.insert(
+            format!("{}.{}", hex::encode(target_sha256), target_name),
+            path.to_owned(),
+        );
+        self.targets_meta
+            .targets
+            .insert(target_name, path.to_owned());
+
+        Ok(())
+    }
+
+    pub fn build<'a, P1, P2, T>(
+        &mut self,
+        root_path: P1,
+        keys: Vec<Box<dyn KeySource>>,
+        datastore: P2,
+    ) -> Result<Repository<'a, T>>
+    where
+        P1: AsRef<Path>,
+        P2: AsRef<Path>,
+        T: Transport,
+    {
+        let root_path = root_path.as_ref().to_owned();
+        let root_buf = std::fs::read(&root_path).context(error::FileRead { path: &root_path })?;
+        let signed_root = serde_json::from_slice::<Signed<Root>>(&root_buf)
+            .context(error::FileParseJson { path: &root_path })?;
+        let root_digest = RootDigest::load(&root_path)?;
+        let key_pairs = root_digest.load_keys(&keys)?;
+
+        let rng = SystemRandom::new();
+
+        let mut signed_targets = Signed {
+            signed: self.targets.clone(),
+            signatures: Vec::new(),
+        };
+        let (targets_sha256, targets_length) = RepositoryEditor::sign_role(
+            datastore.as_ref(),
+            &root_digest.root,
+            &key_pairs,
+            &mut signed_targets,
+            self.targets.version,
+            &rng,
+            "targets.json",
+        )?;
+
+        // =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
+        // Update and sign snapshot
+        self.snapshot.meta = hashmap! {
+            "root.json".to_owned() => SnapshotMeta {
+                hashes: Some(Hashes {
+                    sha256: root_digest.digest.to_vec().into(),
+                    _extra: HashMap::new(),
+                }),
+                length: Some(root_digest.size),
+                version: root_digest.root.version,
+                _extra: HashMap::new(),
+            },
+            "targets.json".to_owned() => SnapshotMeta {
+                hashes: Some(Hashes {
+                    sha256: targets_sha256.to_vec().into(),
+                    _extra: HashMap::new(),
+                }),
+                length: Some(targets_length),
+                version: self.targets.version,
+                _extra: HashMap::new(),
+            },
+        };
+        let mut signed_snapshot = Signed {
+            signed: self.snapshot.clone(),
+            signatures: Vec::new(),
+        };
+        let (snapshot_sha256, snapshot_length) = RepositoryEditor::sign_role(
+            datastore.as_ref(),
+            &root_digest.root,
+            &key_pairs,
+            &mut signed_snapshot,
+            self.snapshot.version,
+            &rng,
+            "snapshot.json",
+        )?;
+
+        // =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
+        // Update and sign timestamp
+        self.timestamp.meta = hashmap! {
+            "snapshot.json".to_owned() => TimestampMeta {
+                hashes: Hashes {
+                    sha256: snapshot_sha256.to_vec().into(),
+                    _extra: HashMap::new(),
+                },
+                length: snapshot_length,
+                version: self.snapshot.version,
+                _extra: HashMap::new(),
+            }
+        };
+        let mut signed_timestamp = Signed {
+            signed: self.timestamp.clone(),
+            signatures: Vec::new(),
+        };
+        let (_timestamp_sha256, _timestamp_length) = RepositoryEditor::sign_role(
+            datastore.as_ref(),
+            &root_digest.root,
+            &key_pairs,
+            &mut signed_timestamp,
+            self.timestamp.version,
+            &rng,
+            "timestamp.json",
+        )?;
+
+        let expires_iter = [
+            (root_digest.root.expires, RoleType::Root),
+            (self.timestamp.expires, RoleType::Timestamp),
+            (self.snapshot.expires, RoleType::Snapshot),
+            (self.targets.expires, RoleType::Targets),
+        ];
+        let (earliest_expiration, earliest_expiration_role) =
+            expires_iter.iter().min_by_key(|tup| tup.0).unwrap();
+
+        let repo = Repository {
+            transport: TargetMapTransport {
+                targets: HashMap::new(),
+            },
+            consistent_snapshot: true,
+            datastore: Datastore::new(datastore.as_ref()),
+            earliest_expiration: earliest_expiration.to_owned(),
+            earliest_expiration_role: *earliest_expiration_role,
+            root: signed_root,
+            snapshot: signed_snapshot,
+            timestamp: signed_timestamp,
+            targets: signed_targets,
+            targets_base_url: Url::parse("target_map:///").context(error::ParseUrl {
+                url: "target_map:///",
+            })?,
+        };
+        Ok(repo)
+    }
+
+    fn sign_role<T, P>(
+        outdir: P,
+        root: &Root,
+        keys: &RootKeys,
+        role: &mut Signed<T>,
+        version: NonZeroU64,
+        rng: &dyn SecureRandom,
+        filename: &'static str,
+    ) -> Result<([u8; SHA256_OUTPUT_LEN], u64)>
+    where
+        T: Role + Serialize,
+        P: AsRef<Path>,
+    {
+        let metadir = outdir.as_ref().join("metadata");
+        std::fs::create_dir_all(&metadir).context(error::FileCreate { path: &metadir })?;
+
+        let path = metadir.join(
+            if T::TYPE != RoleType::Timestamp && root.consistent_snapshot {
+                format!("{}.{}", version, filename)
+            } else {
+                filename.to_owned()
+            },
+        );
+
+        let mut role = Signed {
+            signed: role,
+            signatures: Vec::new(),
+        };
+
+        let role_type = T::TYPE;
+        if let Some(role_keys) = root.roles.get(&role_type) {
+            for (keyid, key) in keys {
+                if role_keys.keyids.contains(&keyid) {
+                    let mut data = Vec::new();
+                    let mut ser = serde_json::Serializer::with_formatter(
+                        &mut data,
+                        CanonicalFormatter::new(),
+                    );
+                    role.signed
+                        .serialize(&mut ser)
+                        .context(error::SerializeRole)?;
+                    let sig = key.sign(&data, rng)?;
+                    role.signatures.push(Signature {
+                        keyid: keyid.clone(),
+                        sig: sig.into(),
+                    });
+                }
+            }
+        }
+
+        let mut buf = serde_json::to_vec_pretty(&role).context(error::SerializeSignedRole)?;
+        buf.push(b'\n');
+        std::fs::write(&path, &buf).context(error::FileCreate { path: &path })?;
+
+        let mut sha256 = [0; SHA256_OUTPUT_LEN];
+        sha256.copy_from_slice(digest(&SHA256, &buf).as_ref());
+        Ok((sha256, buf.len() as u64))
+    }
+}
+
+//impl TryFrom<Repository<'a>> for RepositoryEditor {}

--- a/tough/src/error.rs
+++ b/tough/src/error.rs
@@ -18,6 +18,14 @@ pub type Result<T> = std::result::Result<T, Error>;
 #[snafu(visibility = "pub(crate)")]
 pub enum Error {
     /// The library failed to create a file in the datastore.
+    #[snafu(display("Unable to canonicalize path '{}': {}", path.display(), source))]
+    AbsolutePath {
+        path: PathBuf,
+        source: std::io::Error,
+        backtrace: Backtrace,
+    },
+
+    /// The library failed to create a file in the datastore.
     #[snafu(display("Failed to create file at datastore path {}: {}", path.display(), source))]
     DatastoreCreate {
         path: PathBuf,
@@ -54,6 +62,13 @@ pub enum Error {
     #[snafu(display("{} metadata is expired", role))]
     ExpiredMetadata {
         role: RoleType,
+        backtrace: Backtrace,
+    },
+
+    #[snafu(display("Failed to create {}: {}", path.display(), source))]
+    FileCreate {
+        path: PathBuf,
+        source: std::io::Error,
         backtrace: Backtrace,
     },
 
@@ -191,6 +206,18 @@ pub enum Error {
         backtrace: Backtrace,
     },
 
+    #[snafu(display("Failed to serialize role for signing: {}", source))]
+    SerializeRole {
+        source: serde_json::Error,
+        backtrace: Backtrace,
+    },
+
+    #[snafu(display("Failed to serialize signed role: {}", source))]
+    SerializeSignedRole {
+        source: serde_json::Error,
+        backtrace: Backtrace,
+    },
+
     #[snafu(display("Failed to sign message"))]
     Sign {
         source: ring::error::Unspecified,
@@ -206,6 +233,13 @@ pub enum Error {
     SystemTimeSteppedBackward {
         sys_time: DateTime<Utc>,
         latest_known_time: DateTime<Utc>,
+    },
+
+    #[snafu(display("Unable to create Target from path '{}': {}", path.display(), source))]
+    TargetFromPath {
+        path: PathBuf,
+        source: crate::schema::Error,
+        backtrace: Backtrace,
     },
 
     /// A transport error occurred while fetching a URL.

--- a/tough/src/error.rs
+++ b/tough/src/error.rs
@@ -57,6 +57,13 @@ pub enum Error {
         backtrace: Backtrace,
     },
 
+    #[snafu(display("Failed to parse {}: {}", path.display(), source))]
+    FileParseJson {
+        path: PathBuf,
+        source: serde_json::Error,
+        backtrace: Backtrace,
+    },
+
     #[snafu(display("Failed to read {}: {}", path.display(), source))]
     FileRead {
         path: PathBuf,
@@ -103,6 +110,15 @@ pub enum Error {
 
     #[snafu(display("Unrecognized private key format"))]
     KeyUnrecognized { backtrace: Backtrace },
+
+    #[snafu(display("Unable to parse keypair: {}", source))]
+    KeyPairFromKeySource {
+        source: Box<dyn std::error::Error + Send + Sync + 'static>,
+        backtrace: Backtrace,
+    },
+
+    #[snafu(display("Unable to match any of the provided keys with root.json"))]
+    KeysNotFoundInRoot { backtrace: Backtrace },
 
     /// A file's maximum size exceeded a limit set by the consumer of this library or the metadata.
     #[snafu(display("Maximum size {} (specified by {}) exceeded", max_size, specifier))]

--- a/tough/src/lib.rs
+++ b/tough/src/lib.rs
@@ -21,6 +21,7 @@
 )]
 
 mod datastore;
+pub mod editor;
 pub mod error;
 mod fetch;
 mod io;

--- a/tough/src/lib.rs
+++ b/tough/src/lib.rs
@@ -25,6 +25,7 @@ pub mod error;
 mod fetch;
 mod io;
 pub mod key_source;
+pub mod root_digest;
 pub mod schema;
 pub mod sign;
 mod transport;

--- a/tough/src/schema/error.rs
+++ b/tough/src/schema/error.rs
@@ -5,6 +5,7 @@
 use crate::schema::RoleType;
 use snafu::{Backtrace, Snafu};
 use std::fmt::{self, Debug, Display};
+use std::path::PathBuf;
 
 /// Alias for `Result<T, Error>`.
 pub type Result<T> = std::result::Result<T, Error>;
@@ -16,6 +17,22 @@ pub enum Error {
     /// A duplicate key ID was present in the root metadata.
     #[snafu(display("Duplicate key ID: {}", keyid))]
     DuplicateKeyId { keyid: String },
+
+    /// Unable to open a file
+    #[snafu(display("Failed to open {}: {}", path.display(), source))]
+    FileOpen {
+        path: PathBuf,
+        source: std::io::Error,
+        backtrace: Backtrace,
+    },
+
+    /// Unable to read the file
+    #[snafu(display("Failed to read {}: {}", path.display(), source))]
+    FileRead {
+        path: PathBuf,
+        source: std::io::Error,
+        backtrace: Backtrace,
+    },
 
     /// A downloaded target's checksum does not match the checksum listed in the repository
     /// metadata.
@@ -48,12 +65,20 @@ pub enum Error {
         backtrace: Backtrace,
     },
 
+    /// Unable to determine file name (path ends in '..' or is '/')
+    #[snafu(display("Unable to determine file name from path: '{}'", path.display()))]
+    NoFileName { path: PathBuf, backtrace: Backtrace },
+
     /// Failed to decode a PEM-encoded key.
     #[snafu(display("Invalid PEM string: {}", source))]
     PemDecode {
         source: Compat<pem::PemError>,
         backtrace: Backtrace,
     },
+
+    /// Path isn't a valid UTF8 string
+    #[snafu(display("Path {} is not valid UTF-8", path.display()))]
+    PathUtf8 { path: PathBuf, backtrace: Backtrace },
 
     /// A signature threshold specified in root.json was not met when verifying a signature.
     #[snafu(display(
@@ -72,6 +97,10 @@ pub enum Error {
     /// Failed to extract a bit string from a `SubjectPublicKeyInfo` document.
     #[snafu(display("Invalid SubjectPublicKeyInfo document"))]
     SpkiDecode { backtrace: Backtrace },
+
+    /// Unable to create a TUF target from anything but a file
+    #[snafu(display("TUF targets must be files, given: '{}'", path.display()))]
+    TargetNotAFile { path: PathBuf, backtrace: Backtrace },
 }
 
 /// Wrapper for error types that don't impl [`std::error::Error`].

--- a/tough/src/schema/mod.rs
+++ b/tough/src/schema/mod.rs
@@ -245,7 +245,7 @@ impl Target {
             .file_name()
             .context(error::NoFileName { path })?
             .to_str()
-            .context(error::PathUtf8 { path: path })?
+            .context(error::PathUtf8 { path })?
             .to_owned();
 
         let mut file = File::open(path).context(error::FileOpen { path })?;

--- a/tough/src/schema/mod.rs
+++ b/tough/src/schema/mod.rs
@@ -15,12 +15,16 @@ use crate::schema::iter::KeysIter;
 use crate::schema::key::Key;
 use chrono::{DateTime, Utc};
 use olpc_cjson::CanonicalFormatter;
+use ring::digest::{Context, SHA256};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use serde_plain::{forward_display_to_serde, forward_from_str_to_serde};
-use snafu::ResultExt;
+use snafu::{OptionExt, ResultExt};
 use std::collections::HashMap;
+use std::fs::File;
+use std::io::Read;
 use std::num::NonZeroU64;
+use std::path::Path;
 
 /// A role type.
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, Hash)]
@@ -222,6 +226,54 @@ pub struct Target {
     /// If you're instantiating this struct, you should make this `HashMap::empty()`.
     #[serde(flatten)]
     pub _extra: HashMap<String, Value>,
+}
+
+impl Target {
+    /// Given a path, returns the target filename and Target object
+    pub fn from_path<P>(path: P) -> Result<(String, Target)>
+    where
+        P: AsRef<Path>,
+    {
+        // Ensure the given path is a file
+        let path = path.as_ref();
+        if !path.is_file() {
+            return error::TargetNotAFile { path }.fail();
+        }
+
+        // Get the file name as a string
+        let target_name = path
+            .file_name()
+            .context(error::NoFileName { path })?
+            .to_str()
+            .context(error::PathUtf8 { path: path })?
+            .to_owned();
+
+        let mut file = File::open(path).context(error::FileOpen { path })?;
+        let mut digest = Context::new(&SHA256);
+        let mut buf = [0; 8 * 1024];
+        let mut length = 0;
+        loop {
+            match file.read(&mut buf).context(error::FileRead { path })? {
+                0 => break,
+                n => {
+                    digest.update(&buf[..n]);
+                    length += n as u64;
+                }
+            }
+        }
+
+        let target = Target {
+            length,
+            hashes: Hashes {
+                sha256: Decoded::from(digest.finish().as_ref().to_vec()),
+                _extra: HashMap::new(),
+            },
+            custom: HashMap::new(),
+            _extra: HashMap::new(),
+        };
+
+        Ok((target_name, target))
+    }
 }
 
 impl Role for Targets {

--- a/tuftool/src/create.rs
+++ b/tuftool/src/create.rs
@@ -3,7 +3,6 @@
 
 use crate::datetime::parse_datetime;
 use crate::error::{self, Result};
-use crate::key::RootKeys;
 use crate::metadata;
 use crate::root_digest::RootDigest;
 use crate::source::parse_key_source;
@@ -21,6 +20,7 @@ use std::num::{NonZeroU64, NonZeroUsize};
 use std::path::{Path, PathBuf};
 use structopt::StructOpt;
 use tough::key_source::KeySource;
+use tough::root_digest::RootKeys;
 use tough::schema::{
     decoded::Decoded, Hashes, Role, Snapshot, SnapshotMeta, Target, Targets, Timestamp,
     TimestampMeta,
@@ -84,8 +84,11 @@ impl CreateArgs {
                 .context(error::InitializeThreadPool)?;
         }
 
-        let root_digest = RootDigest::load(&self.root)?;
-        let key_pairs = root_digest.load_keys(&self.keys)?;
+        let root_digest =
+            RootDigest::load(&self.root).context(error::ParseRoot { path: &self.root })?;
+        let key_pairs = root_digest
+            .load_keys(&self.keys)
+            .context(error::KeysFromRoot { path: &self.root })?;
 
         CreateProcess {
             args: self,

--- a/tuftool/src/error.rs
+++ b/tuftool/src/error.rs
@@ -127,6 +127,13 @@ pub(crate) enum Error {
         backtrace: Backtrace,
     },
 
+    #[snafu(display("Unable to retrieve keys from root metadata file '{}': {}", path.display(), source))]
+    KeysFromRoot {
+        path: PathBuf,
+        source: tough::error::Error,
+        backtrace: Backtrace,
+    },
+
     #[snafu(display("Failed to calculate key ID: {}", source))]
     KeyId {
         #[snafu(backtrace)]
@@ -144,9 +151,6 @@ pub(crate) enum Error {
         source: Box<dyn std::error::Error + Send + Sync + 'static>,
         backtrace: Backtrace,
     },
-
-    #[snafu(display("Unable to match any of the provided keys with root.json"))]
-    KeysNotFoundInRoot { backtrace: Backtrace },
 
     #[snafu(display("Metadata error: {}", source))]
     Metadata {
@@ -180,6 +184,13 @@ pub(crate) enum Error {
         path: PathBuf,
         base: PathBuf,
         source: std::path::StripPrefixError,
+        backtrace: Backtrace,
+    },
+
+    #[snafu(display("Unable to open and parse root metadata file '{}': {}", path.display(), source))]
+    ParseRoot {
+        path: PathBuf,
+        source: tough::error::Error,
         backtrace: Backtrace,
     },
 

--- a/tuftool/src/key.rs
+++ b/tuftool/src/key.rs
@@ -6,12 +6,8 @@ use olpc_cjson::CanonicalFormatter;
 use ring::rand::SecureRandom;
 use serde::Serialize;
 use snafu::ResultExt;
-use std::collections::HashMap;
-use tough::schema::decoded::{Decoded, Hex};
+use tough::root_digest::RootKeys;
 use tough::schema::{RoleType, Root, Signature, Signed};
-use tough::sign::Sign;
-
-pub(crate) type RootKeys = HashMap<Decoded<Hex>, Box<dyn Sign>>;
 
 pub(crate) fn sign_metadata<T: Serialize>(
     root: &Root,

--- a/tuftool/src/main.rs
+++ b/tuftool/src/main.rs
@@ -19,7 +19,6 @@ mod key;
 mod metadata;
 mod refresh;
 mod root;
-mod root_digest;
 mod sign;
 mod source;
 
@@ -30,6 +29,7 @@ use std::io::Write;
 use std::path::Path;
 use structopt::StructOpt;
 use tempfile::NamedTempFile;
+use tough::root_digest;
 
 static SPEC_VERSION: &str = "1.0.0";
 

--- a/tuftool/src/metadata.rs
+++ b/tuftool/src/metadata.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use crate::error::{self, Result};
-use crate::key::RootKeys;
 use olpc_cjson::CanonicalFormatter;
 use ring::digest::{digest, SHA256, SHA256_OUTPUT_LEN};
 use ring::rand::SecureRandom;
@@ -10,6 +9,7 @@ use serde::Serialize;
 use snafu::ResultExt;
 use std::num::NonZeroU64;
 use std::path::PathBuf;
+use tough::root_digest::RootKeys;
 use tough::schema::{Role, RoleType, Root, Signature, Signed};
 
 fn sign_metadata_inner<T: Serialize>(

--- a/tuftool/src/refresh.rs
+++ b/tuftool/src/refresh.rs
@@ -110,10 +110,13 @@ impl RefreshArgs {
         };
 
         // load the root.json file
-        let root_digest = RootDigest::load(&self.root)?;
+        let root_digest =
+            RootDigest::load(&self.root).context(error::ParseRoot { path: &self.root })?;
 
         // match the command line keys to the root.json keys
-        let keys = root_digest.load_keys(&self.keys)?;
+        let keys = root_digest
+            .load_keys(&self.keys)
+            .context(error::KeysFromRoot { path: &self.root })?;
 
         // sign and write out the new targets.json file
         let rng = SystemRandom::new();


### PR DESCRIPTION
Best to read these commits in order:

* `Add from_path() to Target` : This just adds a method to `Target` so we can create one from a `Path`

* `Move RootDigest to tough`: This moves the `RootDigest` abstraction out of `tuftool` into `tough`

* `Add RepositoryEditor`: This is where I need the most help. 